### PR TITLE
Fix exit status handling in url-activa.sh

### DIFF
--- a/bash/archivos/url-activa.sh
+++ b/bash/archivos/url-activa.sh
@@ -9,14 +9,16 @@
 if [[ -z "$1" ]]; then
   echo -e "Uso:\n url-activa.sh [URL]"
 else
-  ping -c 4 $1 > /dev/null
-  if [[ "$?" == "0" ]]; then
-     echo "Ping exitoso"
-    curl -s $1 > /dev/null
-    if [[ "$?" == "0" ]]; then
+  ping -c 4 "$1" > /dev/null
+  ping_status=$?
+  if [[ $ping_status == 0 ]]; then
+    echo "Ping exitoso"
+    if curl -s "$1" > /dev/null; then
       echo "La pagina esta activa y responde a web"
+    else
+      echo "La pagina no responde via HTTP"
     fi
   else
-    echo "La pagina no responde ($?)"  
+    echo "La pagina no responde ($ping_status)"
   fi
 fi


### PR DESCRIPTION
## Summary
- capture the exit status of `ping` properly
- check HTTP reachability with `curl` directly
- add quoting for robustness
- pass ShellCheck

## Testing
- `shellcheck bash/archivos/url-activa.sh`
- `bash bash/archivos/url-activa.sh invalidhost`

------
https://chatgpt.com/codex/tasks/task_e_68405e5f66d883248e71353f21aaf52c